### PR TITLE
Add `.github/workflows/remind_secrets_expiration.yaml`

### DIFF
--- a/.github/workflows/remind_secrets_expiration.yaml
+++ b/.github/workflows/remind_secrets_expiration.yaml
@@ -1,0 +1,31 @@
+name: Reminder to update secrets
+
+on:
+  schedule:
+    - cron: "0 0 1 4 *" # Define the cron schedule for April 1st
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  schedule_issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get year
+        id: year
+        run: |
+          year=$(date +%Y)
+          echo "year=$year" > $GITHUB_OUTPUT
+
+      - name: Create issue
+        uses: imjohnbo/issue-bot@v3.4.3
+        with:
+          assignees: "ethanthatonekid"
+          labels: "automation"
+          title: "Update secrets for ${{ steps.year.outputs.year }}"
+          body: "The secrets for ${{ steps.year.outputs.year }} need to be updated. See the `README.md` file for more information."
+          pinned: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I struggled with naming this workflow. For now, it is `.github/workflows/remind_secrets_expiration.yaml`.

The `.github/workflows/remind_secrets_expiration.yaml` file is a GitHub Workflow written in YAML format. It sets up a scheduled task to remind a user to update secrets on April 1st every year. It also allows for manual trigger of the workflow.

The workflow runs on an Ubuntu environment and consists of the following steps:

1. **Checkout Repository**: It checks out the repository using the `actions/checkout@v2` action.

2. **Get year**: It runs a shell script to get the current year using the `date` command and stores it as an output named `year` using the `GITHUB_OUTPUT` environment variable.

3. **Create issue**: It uses the `imjohnbo/issue-bot@v3.4.3` action to create an issue. The issue is assigned to the user "ethanthatonekid", labeled as "automation", and titled "Update secrets for {year}", where `{year}` is replaced with the value obtained from the previous step. The issue body contains a reminder message to update secrets for the current year, with a reference to the `README.md` file for more information. The issue is also pinned for easy visibility.

The workflow is triggered on April 1st every year based on a defined cron schedule, but it can also be manually triggered using the "workflow_dispatch" event.
